### PR TITLE
fix(imports): Updating nats imports to new path

### DIFF
--- a/broker/nats/nats.go
+++ b/broker/nats/nats.go
@@ -8,7 +8,7 @@ import (
 	"github.com/divisionone/go-micro/broker"
 	"github.com/divisionone/go-micro/broker/codec/json"
 	"github.com/divisionone/go-micro/cmd"
-	"github.com/nats-io/nats"
+	"github.com/nats-io/nats.go"
 
 	"sync"
 )

--- a/broker/nats/options.go
+++ b/broker/nats/options.go
@@ -4,7 +4,7 @@ import (
 	"context"
 
 	"github.com/divisionone/go-micro/broker"
-	"github.com/nats-io/nats"
+	"github.com/nats-io/nats.go"
 )
 
 type optionsKey struct{}

--- a/registry/nats/nats.go
+++ b/registry/nats/nats.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/divisionone/go-micro/cmd"
 	"github.com/divisionone/go-micro/registry"
-	"github.com/nats-io/nats"
+	"github.com/nats-io/nats.go"
 )
 
 type natsRegistry struct {

--- a/registry/nats/options.go
+++ b/registry/nats/options.go
@@ -4,7 +4,7 @@ import (
 	"context"
 
 	"github.com/divisionone/go-micro/registry"
-	"github.com/nats-io/nats"
+	"github.com/nats-io/nats.go"
 )
 
 type contextQuorumKey struct{}

--- a/registry/nats/watcher.go
+++ b/registry/nats/watcher.go
@@ -5,7 +5,7 @@ import (
 	"time"
 
 	"github.com/divisionone/go-micro/registry"
-	"github.com/nats-io/nats"
+	"github.com/nats-io/nats.go"
 )
 
 type natsWatcher struct {

--- a/transport/nats/nats.go
+++ b/transport/nats/nats.go
@@ -13,7 +13,7 @@ import (
 	"github.com/divisionone/go-micro/server"
 	"github.com/divisionone/go-micro/transport"
 	"github.com/divisionone/go-micro/transport/codec/json"
-	"github.com/nats-io/nats"
+	"github.com/nats-io/nats.go"
 )
 
 type ntport struct {

--- a/transport/nats/options.go
+++ b/transport/nats/options.go
@@ -4,7 +4,7 @@ import (
 	"context"
 
 	"github.com/divisionone/go-micro/transport"
-	"github.com/nats-io/nats"
+	"github.com/nats-io/nats.go"
 )
 
 type optionsKey struct{}


### PR DESCRIPTION
Looks like `nats` have finished changing their client library repository name for now. Time to synchronise. This should also make `go mod` happier.