### PR TITLE
Fix NATS broker reconnect churn during outages

### DIFF
--- a/broker/nats/nats.go
+++ b/broker/nats/nats.go
@@ -90,7 +90,6 @@ func setAddrs(addrs []string) []string {
 func (n *nbroker) Connect() error {
 	n.Lock()
 	defer n.Unlock()
-
 	if n.conn != nil && !n.conn.IsClosed() {
 		return nil
 	}

--- a/broker/nats/nats.go
+++ b/broker/nats/nats.go
@@ -90,8 +90,12 @@ func setAddrs(addrs []string) []string {
 func (n *nbroker) Connect() error {
 	n.Lock()
 	defer n.Unlock()
-	if n.conn != nil && n.conn.IsConnected() {
-		return nil
+
+	if n.conn != nil {
+		switch n.conn.Status() {
+		case nats.CONNECTED, nats.RECONNECTING, nats.DISCONNECTED, nats.DRAINING_SUBS, nats.DRAINING_PUBS:
+			return nil
+		}
 	}
 
 	opts := n.nopts

--- a/broker/nats/nats.go
+++ b/broker/nats/nats.go
@@ -91,11 +91,8 @@ func (n *nbroker) Connect() error {
 	n.Lock()
 	defer n.Unlock()
 
-	if n.conn != nil {
-		switch n.conn.Status() {
-		case nats.CONNECTED, nats.RECONNECTING, nats.DISCONNECTED, nats.DRAINING_SUBS, nats.DRAINING_PUBS:
-			return nil
-		}
+	if n.conn != nil && !n.conn.IsClosed() {
+		return nil
 	}
 
 	opts := n.nopts


### PR DESCRIPTION
This changes the github.com/divisionone/go-plugins NATS broker to reuse an existing nats.Conn while it is reconnecting instead of creating replacement connections on repeated Connect() calls.

Previously, broker/nats.Connect() only short-circuited when conn.IsConnected() was true. During a broker outage, an existing connection in RECONNECTING state returns false for IsConnected(), so repeated publish/subscribe paths could call Connect() and create additional nats.Conn instances in the same process. When NATS came back, those extra connections could all reconnect, which is consistent with reconnect callback storms and can contribute to duplicated subscription restoration or buffered publish flush behavior.

The updated logic treats these connection states as reusable and does not create a new connection when one already exists in:

CONNECTED
RECONNECTING
DISCONNECTED
DRAINING_SUBS
DRAINING_PUBS

This keeps one logical broker connection per process through reconnect events instead of fanning out under load.